### PR TITLE
fix: Kotlin MacOS Arm64 native target

### DIFF
--- a/anoncreds/build-kotlin-library.sh
+++ b/anoncreds/build-kotlin-library.sh
@@ -25,11 +25,19 @@ for target in "${apple_targets[@]}"; do
   cargo build --release --target $target
 done
 
-# # Merge libraries with lipo
-mkdir -p $OUT_PATH/macos-native/
+# Merge mac libraries with lipo
+mkdir -p $OUT_PATH/macos-native/static
+mkdir -p $OUT_PATH/macos-native/dynamic
+
+# dylib for JVM
 lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.dylib \
              $X86_64_APPLE_DARWIN_PATH/lib$NAME.dylib \
-     -output $OUT_PATH/macos-native/lib$NAME.dylib
+     -output $OUT_PATH/macos-native/dynamic/lib$NAME.dylib
+
+# .a for Native
+lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.a \
+             $X86_64_APPLE_DARWIN_PATH/lib$NAME.a \
+     -output $OUT_PATH/macos-native/static/lib$NAME.a
 
 cargo install cross --git https://github.com/cross-rs/cross
 

--- a/askar/build-kotlin-library.sh
+++ b/askar/build-kotlin-library.sh
@@ -25,11 +25,19 @@ for target in "${apple_targets[@]}"; do
   cargo build --release --target $target
 done
 
-# # Merge libraries with lipo
-mkdir -p $OUT_PATH/macos-native/
+# Merge mac libraries with lipo
+mkdir -p $OUT_PATH/macos-native/static
+mkdir -p $OUT_PATH/macos-native/dynamic
+
+# dylib for JVM
 lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.dylib \
              $X86_64_APPLE_DARWIN_PATH/lib$NAME.dylib \
-     -output $OUT_PATH/macos-native/lib$NAME.dylib
+     -output $OUT_PATH/macos-native/dynamic/lib$NAME.dylib
+
+# .a for Native
+lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.a \
+             $X86_64_APPLE_DARWIN_PATH/lib$NAME.a \
+     -output $OUT_PATH/macos-native/static/lib$NAME.a
 
 cargo install cross --git https://github.com/cross-rs/cross
 

--- a/indy-vdr/build-kotlin-library.sh
+++ b/indy-vdr/build-kotlin-library.sh
@@ -26,11 +26,19 @@ for target in "${apple_targets[@]}"; do
   cargo build --release --target $target
 done
 
-# Merge libraries with lipo
-mkdir -p $OUT_PATH/macos-native/
+# Merge mac libraries with lipo
+mkdir -p $OUT_PATH/macos-native/static
+mkdir -p $OUT_PATH/macos-native/dynamic
+
+# dylib for JVM
 lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.dylib \
              $X86_64_APPLE_DARWIN_PATH/lib$NAME.dylib \
-     -output $OUT_PATH/macos-native/lib$NAME.dylib
+     -output $OUT_PATH/macos-native/dynamic/lib$NAME.dylib
+
+# .a for Native
+lipo -create $AARCH64_APPLE_DARWIN_PATH/lib$NAME.a \
+             $X86_64_APPLE_DARWIN_PATH/lib$NAME.a \
+     -output $OUT_PATH/macos-native/static/lib$NAME.a
 
 cargo install cross --git https://github.com/cross-rs/cross
 

--- a/kotlin/anoncreds/build.gradle.kts
+++ b/kotlin/anoncreds/build.gradle.kts
@@ -44,7 +44,7 @@ val processBinaries = tasks.register("processBinaries", Copy::class) {
         .resolve("jvm")
         .resolve("main")
 
-    from(uniffiBindings.resolve("macos-native"))
+    from(uniffiBindings.resolve("macos-native").resolve("dynamic"))
     include("*.dylib")
     into(directory)
 }
@@ -158,12 +158,12 @@ kotlin {
     }
 
     macosX64{
-        val libDirectory = "${anoncredsDir}/target/x86_64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 
     macosArm64{
-        val libDirectory = "${anoncredsDir}/target/aarch64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 

--- a/kotlin/anoncreds/src/nativeInterop/cinterop/uniffi.def
+++ b/kotlin/anoncreds/src/nativeInterop/cinterop/uniffi.def
@@ -8,5 +8,4 @@ libraryPaths.ios_arm64 = ../../anoncreds/target/aarch64-apple-ios/release
 libraryPaths.ios_simulator_arm64 = ../../anoncreds/target/aarch64-apple-ios-sim/release
 
 staticLibraries.osx = libanoncreds_uniffi.a
-libraryPaths.macos_x64 = ../../anoncreds/target/x86_64-apple-darwin/release ../../anoncreds/target/aarch64-apple-darwin/release
-libraryPaths.macos_arm64 = ../../anoncreds/target/aarch64-apple-darwin/release ../../anoncreds/target/x86_64-apple-darwin/release
+libraryPaths.osx = ../../anoncreds/out/kmpp-uniffi/macos-native/static

--- a/kotlin/askar/build.gradle.kts
+++ b/kotlin/askar/build.gradle.kts
@@ -43,7 +43,7 @@ val processBinaries = tasks.register("processBinaries", Copy::class) {
         .resolve("jvm")
         .resolve("main")
 
-    from(uniffiBindings.resolve("macos-native"))
+    from(uniffiBindings.resolve("macos-native").resolve("dynamic"))
     include("*.dylib")
     into(directory)
 }
@@ -157,12 +157,12 @@ kotlin {
     }
 
     macosX64{
-        val libDirectory = "${askarDir}/target/x86_64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 
     macosArm64{
-        val libDirectory = "${askarDir}/target/aarch64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 

--- a/kotlin/askar/src/nativeInterop/cinterop/uniffi.def
+++ b/kotlin/askar/src/nativeInterop/cinterop/uniffi.def
@@ -8,5 +8,4 @@ libraryPaths.ios_arm64 = ../../askar/target/aarch64-apple-ios/release
 libraryPaths.ios_simulator_arm64 = ../../askar/target/aarch64-apple-ios-sim/release
 
 staticLibraries.osx = libaskar_uniffi.a
-libraryPaths.macos_x64 = ../../askar/target/x86_64-apple-darwin/release ../../askar/target/aarch64-apple-darwin/release
-libraryPaths.macos_arm64 = ../../askar/target/aarch64-apple-darwin/release ../../askar/target/x86_64-apple-darwin/release
+libraryPaths.osx = ../../askar/out/kmpp-uniffi/macos-native/static

--- a/kotlin/indy-vdr/build.gradle.kts
+++ b/kotlin/indy-vdr/build.gradle.kts
@@ -43,7 +43,7 @@ val processBinaries = tasks.register("processBinaries", Copy::class) {
         .resolve("jvm")
         .resolve("main")
 
-    from(uniffiBindings.resolve("macos-native"))
+    from(uniffiBindings.resolve("macos-native").resolve("dynamic"))
     include("*.dylib")
     into(directory)
 }
@@ -157,12 +157,12 @@ kotlin {
     }
 
     macosX64{
-        val libDirectory = "${vdrDir}/target/x86_64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 
     macosArm64{
-        val libDirectory = "${vdrDir}/target/aarch64-apple-darwin/release"
+        val libDirectory = "${uniffiBindings}/macos-native/static"
         addLibs(libDirectory, this)
     }
 

--- a/kotlin/indy-vdr/src/nativeInterop/cinterop/uniffi.def
+++ b/kotlin/indy-vdr/src/nativeInterop/cinterop/uniffi.def
@@ -8,5 +8,4 @@ libraryPaths.ios_arm64 = ../../indy-vdr/target/aarch64-apple-ios/release
 libraryPaths.ios_simulator_arm64 = ../../indy-vdr/target/aarch64-apple-ios-sim/release
 
 staticLibraries.osx = libindy_vdr_uniffi.a
-libraryPaths.macos_x64 = ../../indy-vdr/target/x86_64-apple-darwin/release ../../indy-vdr/target/aarch64-apple-darwin/release
-libraryPaths.macos_arm64 = ../../indy-vdr/target/aarch64-apple-darwin/release ../../indy-vdr/target/x86_64-apple-darwin/release
+libraryPaths.osx = ../../indy-vdr/out/kmpp-uniffi/macos-native/static


### PR DESCRIPTION
Creates a universal static library for MacOS in the buildscript. Fixes issues we were having with M-series mac targets.